### PR TITLE
feat: Add support for UNIX socket

### DIFF
--- a/main.go
+++ b/main.go
@@ -329,7 +329,7 @@ func (ac *activityConnection) play(details Details) error {
 		}
 	}
 
-	var timeStamps = client.Timestamps{}
+	timeStamps := client.Timestamps{}
 	timeStamps.Start = &start
 
 	if c.RP.Time == "remaining" {
@@ -376,10 +376,10 @@ func firstNonEmpty(ss ...string) string {
 }
 
 type Config struct {
-	Branding string
+	Branding  string
 	UseSocket bool `mapstructure:"use_socket"`
-	Host     string
-	Port     uint16
+	Host      string
+	Port      uint16
 
 	Sleep struct {
 		Long  time.Duration

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ func init() {
 	v.AddConfigPath(".")
 
 	v.SetDefault("branding", "mpd")
+	v.SetDefault("use_socket", false)
 	v.SetDefault("host", "127.0.0.1")
 	v.SetDefault("port", 6600)
 
@@ -77,7 +78,11 @@ func main() {
 		lastfmAPI = lastfm.New(c.LastFM.APIKey, c.LastFM.APISecret)
 	}
 
-	mpdClient, err = mpd.Dial("tcp", fmt.Sprintf("%s:%d", c.Host, c.Port))
+	if c.UseSocket {
+		mpdClient, err = mpd.Dial("unix", fmt.Sprintf("%s", c.Host))
+	} else {
+		mpdClient, err = mpd.Dial("tcp", fmt.Sprintf("%s:%d", c.Host, c.Port))
+	}
 	if err != nil {
 		log.WithError(err).Fatal("failed to connect to MPD server")
 	}
@@ -372,6 +377,7 @@ func firstNonEmpty(ss ...string) string {
 
 type Config struct {
 	Branding string
+	UseSocket bool `mapstructure:"use_socket"`
 	Host     string
 	Port     uint16
 


### PR DESCRIPTION
**[why]**
At present this app only supports TCP connection to an MPD host. I use a UNIX socket for MPD, and this quick patch should add support for it. Let me know what you think. (I closed the older pull request because I wanted to apply this change on a feature branch first.)

**[how]**
I added a new configuration variable `use_socket` that takes a Boolean value. If set to `true`, `mpd.Dial()` should take `"unix"` as its first argument, indicating that it's connecting to a UNIX socket, followed by the location of that socket in the filesystem, set by the configuration variable `host`. The `port` variable is therefore unused in this mode.