### PR TITLE
feat: Allow custom Discord app ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ port: 6600
 branding: mpd
 
 rich_presence:
+  appid: "1037215044141854721" # default Discord app id
   # available keys are:
   # %album%
   # %artist%

--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func init() {
 	v.SetDefault("sleep.long", 30*time.Second)
 	v.SetDefault("sleep.short", 5*time.Second)
 
+	v.SetDefault("rich_presence.appid", "1037215044141854721")
 	v.SetDefault("rich_presence.image.large", "%album%")
 	v.SetDefault("rich_presence.image.small", "%title%")
 	v.SetDefault("rich_presence.upper", "%title%")
@@ -308,7 +309,7 @@ func (ac *activityConnection) play(details Details) error {
 	start := time.Now().Add(-1 * details.Position)
 	end := time.Now().Add(song.Duration - details.Position)
 	if !ac.connected {
-		if err := client.Login("1037215044141854721"); err != nil {
+		if err := client.Login(c.RP.AppID); err != nil {
 			log.WithError(err).Fatal("could not create rich presence client")
 		}
 		ac.connected = true
@@ -380,6 +381,7 @@ type Config struct {
 		Short time.Duration
 	}
 	RP struct {
+		AppID  string
 		Image struct {
 			Large string
 			Small string


### PR DESCRIPTION
**[why]**
A custom Discord App ID would allow users to use a different name and different assets for the Rich Presence status.
Fixes #3.

**[how]**
I added a new, optional configuration key under `rich_presence` named `appid`. If not defined in the configuration file, it would take the default App ID `"1037215044141854721"`; else it would use the configured ID.