### PR TITLE
feat: Add key for mpd version

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ rich_presence:
   # %genre%
   # %title%
   # %year%
+  # %mpdver%
   image:
     large: "%album% (%year%)"
     small: "%title%"

--- a/main.go
+++ b/main.go
@@ -218,6 +218,7 @@ func fmtActivity(s string, d Details) string {
 	s = strings.ReplaceAll(s, "%title%", song.Name)
 	s = strings.ReplaceAll(s, "%year%", strconv.Itoa(song.Year))
 	s = strings.ReplaceAll(s, "%genre%", song.Genre)
+	s = strings.ReplaceAll(s, "%mpdver%", mpdClient.Version())
 	return s
 }
 


### PR DESCRIPTION
**[why]**
Just because. Thought this was simple enough to implement anyway and shouldn't be a breaking change, and I personally want to show this on the image overlay text.

**[how]**
I defined a key `%mpdver%` that shows the MPD version that is running, using the Go MPD library.